### PR TITLE
fix: 서버 배포 전 오류 수정

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -52,9 +52,6 @@ dependencies {
 	// web client
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-	// h2 database
-	implementation 'com.h2database:h2'
-
 	// Jsoup (크롤링)
 	implementation 'org.jsoup:jsoup:1.17.2'
 }

--- a/server/src/main/java/com/pknuwap/udada/common/exception/BusinessException.java
+++ b/server/src/main/java/com/pknuwap/udada/common/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.pknuwap.udada.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/server/src/main/java/com/pknuwap/udada/common/exception/ErrorCode.java
+++ b/server/src/main/java/com/pknuwap/udada/common/exception/ErrorCode.java
@@ -1,0 +1,30 @@
+package com.pknuwap.udada.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    // 공통
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "로그인된 회원 정보가 없습니다. access token을 잘 작성했는지 확인해주세요."),
+
+    // 북마크
+    BOOKMARK_ALREADY(HttpStatus.BAD_REQUEST, "이미 북마크한 공지사항입니다."),
+    BOOKMARK_INVALID(HttpStatus.BAD_REQUEST, "존재하지 않는 북마크입니다."),
+    BOOKMARK_NOT_OWNED(HttpStatus.BAD_REQUEST, "본인의 북마크만 삭제할 수 있습니다."),
+
+    // 공지사항
+    NOTICE_INVALID(HttpStatus.BAD_REQUEST, "존재하지 않는 공지사항입니다."),
+
+    // 유저
+    USER_INVALID(HttpStatus.BAD_REQUEST, "존재하지 않는 유저입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/server/src/main/java/com/pknuwap/udada/common/exception/ErrorCode.java
+++ b/server/src/main/java/com/pknuwap/udada/common/exception/ErrorCode.java
@@ -6,8 +6,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
-    // 공통
+    // 토큰
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "로그인된 회원 정보가 없습니다. access token을 잘 작성했는지 확인해주세요."),
+    INVALID_KAKAO_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 code입니다."),
 
     // 북마크
     BOOKMARK_ALREADY(HttpStatus.BAD_REQUEST, "이미 북마크한 공지사항입니다."),

--- a/server/src/main/java/com/pknuwap/udada/common/exception/Exceptions.java
+++ b/server/src/main/java/com/pknuwap/udada/common/exception/Exceptions.java
@@ -1,0 +1,16 @@
+package com.pknuwap.udada.common.exception;
+
+import lombok.Getter;
+
+public class Exceptions {
+    @Getter
+    private static final Exceptions instance = new Exceptions();
+
+    private Exceptions() {}
+
+    /** userId가 null 값인지 판별 */
+    public void requireUserId(Long id) {
+        if (id == null) throw new BusinessException(ErrorCode.INVALID_TOKEN);
+    }
+
+}

--- a/server/src/main/java/com/pknuwap/udada/common/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/pknuwap/udada/common/exception/GlobalExceptionHandler.java
@@ -15,11 +15,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(BusinessException e) {
         log.error("[Exception] {} : {}", e.getClass().getSimpleName(), e.getMessage(), e);
+        final ErrorCode error = e.getErrorCode();
         return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.failure(e.getMessage()));
+                .status(error.getStatus())
+                .body(ApiResponse.failure(error));
     }
 }

--- a/server/src/main/java/com/pknuwap/udada/common/response/ApiResponse.java
+++ b/server/src/main/java/com/pknuwap/udada/common/response/ApiResponse.java
@@ -1,25 +1,15 @@
 package com.pknuwap.udada.common.response;
 
-import lombok.Getter;
+import com.pknuwap.udada.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
 
-@Getter
-public class ApiResponse<T> {
-
-    private final boolean success;
-    private final T data;
-    private final String message;
-
-    private ApiResponse(boolean success, T data, String message) {
-        this.success = success;
-        this.data = data;
-        this.message = message;
-    }
+public record ApiResponse<T>(boolean success, int code, T data, String message) {
 
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, data, null);
+        return new ApiResponse<>(true, HttpStatus.OK.value(), data, null);
     }
 
-    public static <T> ApiResponse<T> failure(String message) {
-        return new ApiResponse<>(false, null, message);
+    public static <T> ApiResponse<T> failure(ErrorCode errorCode) {
+        return new ApiResponse<>(false, errorCode.getStatus().value(), null, errorCode.getMessage());
     }
 }

--- a/server/src/main/java/com/pknuwap/udada/controller/NoticeController.java
+++ b/server/src/main/java/com/pknuwap/udada/controller/NoticeController.java
@@ -5,6 +5,7 @@ import com.pknuwap.udada.dto.response.NoticeDetailResponse;
 import com.pknuwap.udada.dto.response.NoticeListResponse;
 import com.pknuwap.udada.service.NoticeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -15,20 +16,19 @@ public class NoticeController {
     private final NoticeService noticeService;
 
     @GetMapping
-    public ApiResponse<NoticeListResponse> getNotices(
+    public ResponseEntity<ApiResponse<NoticeListResponse>> getNotices(
             @RequestParam(required = false) Integer keywordId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
 
         NoticeListResponse response = noticeService.getNoticeList(keywordId, page, size);
-        return ApiResponse.success(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/{noticeId}")
-
-    public ApiResponse<NoticeDetailResponse> getNoticeDetail(@PathVariable Long noticeId) {
+    public ResponseEntity<ApiResponse<NoticeDetailResponse>> getNoticeDetail(@PathVariable Long noticeId) {
         NoticeDetailResponse response = noticeService.getNoticeDetail(noticeId);
 
-        return ApiResponse.success(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/server/src/main/java/com/pknuwap/udada/service/BookmarkService.java
+++ b/server/src/main/java/com/pknuwap/udada/service/BookmarkService.java
@@ -2,6 +2,7 @@ package com.pknuwap.udada.service;
 
 import com.pknuwap.udada.common.exception.BusinessException;
 import com.pknuwap.udada.common.exception.ErrorCode;
+import com.pknuwap.udada.common.exception.Exceptions;
 import com.pknuwap.udada.dto.request.BookmarkRequest;
 import com.pknuwap.udada.dto.response.BookmarkResponse;
 import com.pknuwap.udada.entity.Bookmark;
@@ -28,6 +29,8 @@ public class BookmarkService {
 
     // 북마크 목록 조회
     public BookmarkResponse.ListResponse getBookmarks(Long userId) {
+        Exceptions.getInstance().requireUserId(userId);
+
         List<BookmarkResponse> bookmarks = bookmarkRepository.findAllByUserIdWithNotice(userId)
                 .stream()
                 .map(BookmarkResponse::from)
@@ -39,6 +42,8 @@ public class BookmarkService {
     // 북마크 추가
     @Transactional
     public BookmarkResponse.CreateResponse addBookmark(Long userId, BookmarkRequest request) {
+        Exceptions.getInstance().requireUserId(userId);
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_INVALID));
 
@@ -62,6 +67,8 @@ public class BookmarkService {
     // 북마크 삭제
     @Transactional
     public void deleteBookmark(Long userId, Long bookmarkId) {
+        Exceptions.getInstance().requireUserId(userId);
+
         Bookmark bookmark = bookmarkRepository.findById(bookmarkId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.BOOKMARK_INVALID));
 

--- a/server/src/main/java/com/pknuwap/udada/service/BookmarkService.java
+++ b/server/src/main/java/com/pknuwap/udada/service/BookmarkService.java
@@ -1,5 +1,7 @@
 package com.pknuwap.udada.service;
 
+import com.pknuwap.udada.common.exception.BusinessException;
+import com.pknuwap.udada.common.exception.ErrorCode;
 import com.pknuwap.udada.dto.request.BookmarkRequest;
 import com.pknuwap.udada.dto.response.BookmarkResponse;
 import com.pknuwap.udada.entity.Bookmark;
@@ -38,13 +40,13 @@ public class BookmarkService {
     @Transactional
     public BookmarkResponse.CreateResponse addBookmark(Long userId, BookmarkRequest request) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_INVALID));
 
         Notice notice = noticeRepository.findById(request.getNoticeId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 공지사항입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.BOOKMARK_INVALID));
 
         if (bookmarkRepository.existsByUserIdAndNoticeId(userId, request.getNoticeId())) {
-            throw new IllegalStateException("이미 북마크한 공지사항입니다.");
+            throw new BusinessException(ErrorCode.BOOKMARK_ALREADY);
         }
 
         Bookmark bookmark = Bookmark.builder()
@@ -61,10 +63,10 @@ public class BookmarkService {
     @Transactional
     public void deleteBookmark(Long userId, Long bookmarkId) {
         Bookmark bookmark = bookmarkRepository.findById(bookmarkId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 북마크입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.BOOKMARK_INVALID));
 
         if (!bookmark.getUser().getId().equals(userId)) {
-            throw new IllegalStateException("본인의 북마크만 삭제할 수 있습니다.");
+            throw new BusinessException(ErrorCode.BOOKMARK_NOT_OWNED);
         }
 
         bookmarkRepository.delete(bookmark);

--- a/server/src/main/java/com/pknuwap/udada/service/KakaoAuthService.java
+++ b/server/src/main/java/com/pknuwap/udada/service/KakaoAuthService.java
@@ -1,5 +1,7 @@
 package com.pknuwap.udada.service;
 
+import com.pknuwap.udada.common.exception.BusinessException;
+import com.pknuwap.udada.common.exception.ErrorCode;
 import com.pknuwap.udada.common.jwt.JwtProvider;
 import com.pknuwap.udada.dto.response.AuthResponse;
 import com.pknuwap.udada.dto.response.KakaoTokenResponse;
@@ -10,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,6 +89,10 @@ public class KakaoAuthService {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(formData)
                 .retrieve()
+                .onStatus(status -> status == HttpStatus.BAD_REQUEST, response ->
+                        response.bodyToMono(String.class)
+                                .map(body -> new BusinessException(ErrorCode.INVALID_KAKAO_TOKEN))
+                )
                 .bodyToMono(KakaoTokenResponse.class)
                 .block();
     }

--- a/server/src/main/java/com/pknuwap/udada/service/NoticeService.java
+++ b/server/src/main/java/com/pknuwap/udada/service/NoticeService.java
@@ -1,5 +1,7 @@
 package com.pknuwap.udada.service;
 
+import com.pknuwap.udada.common.exception.BusinessException;
+import com.pknuwap.udada.common.exception.ErrorCode;
 import com.pknuwap.udada.dto.response.NoticeDetailResponse;
 import com.pknuwap.udada.dto.response.NoticeListResponse;
 import com.pknuwap.udada.entity.Notice;
@@ -36,10 +38,10 @@ public class NoticeService {
         return NoticeListResponse.of(dtos, noticePage.getTotalElements());
     }
 
-    //존재하지 않는 공지사항 조회
+    // 공지사항 상세 조회
     public NoticeDetailResponse getNoticeDetail(Long noticeId) {
         Notice notice = noticeRepository.findById(noticeId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 공지사항 입니다. id=" + noticeId));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTICE_INVALID));
 
         return NoticeDetailResponse.from(notice);
     }


### PR DESCRIPTION
## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
- 오류 핸들링 처리가 안 되어 있어, 클라이언트의 잘못된 요청(400 에러)에도 500 서버 에러가 뜨는 문제를 해결했습니다~
  - `ErrorCode`, `BusinessException` 참고해주세용
  - 공통 오류 처리를 위해 `IllegalArgument/StateException` -> `BusinessException`으로 교체했습니당, 비즈니스 로직과 관련한 예외(ex: 잘못된 공지사항 id 등)라면 해당 Exception 클래스를 사용해주세요!!!!
## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 논의하고 싶은 부분 (선택)
> 논의하고 싶은 부분이 있다면 작성해 주세요.

## 참고사항
